### PR TITLE
Add local mocks for network calls

### DIFF
--- a/assets/mockData.js
+++ b/assets/mockData.js
@@ -1,0 +1,48 @@
+// Mock data and network stubs for offline operation
+export const mockUser = { id: 1, name: 'Local User' };
+
+function mockResponse(data) {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
+// Override fetch to return local data for any remote endpoint
+const originalFetch = window.fetch;
+window.fetch = async function(input, init) {
+  const url = typeof input === 'string' ? input : input.url;
+  if (/^https?:/i.test(url)) {
+    if (url.includes('login')) {
+      return mockResponse({ user: mockUser });
+    }
+    return mockResponse({});
+  }
+  return originalFetch(input, init);
+};
+
+// Minimal XMLHttpRequest stub
+const OriginalXHR = window.XMLHttpRequest;
+window.XMLHttpRequest = function() {
+  this.readyState = 0;
+  this.status = 200;
+  this.responseText = '';
+  this.onreadystatechange = null;
+  this.onload = null;
+  this.open = (method, url) => {
+    this._url = url;
+  };
+  this.send = () => {
+    const data = this._url && this._url.includes('login') ? { user: mockUser } : {};
+    this.responseText = JSON.stringify(data);
+    this.readyState = 4;
+    this.onload && this.onload();
+    this.onreadystatechange && this.onreadystatechange();
+  };
+};
+
+// Expose dummy login helper
+export function mockLogin() {
+  return Promise.resolve({ user: mockUser });
+}
+window.mockLogin = mockLogin;

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, interactive-widget=resizes-content"
     />
     <title>Emases</title>
+    <script type="module" src="/assets/mockData.js"></script>
     <script type="module" crossorigin src="/assets/index-CytqvZGY.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DjsUcBaW.css" />
   </head>


### PR DESCRIPTION
## Summary
- add mockData module that stubs fetch/XMLHttpRequest and provides mock login
- load mockData before app bundle so app uses local resources only

## Testing
- `python3 -m http.server >/tmp/server.log 2>&1 & PID=$!`
- `sleep 1`
- `curl -I localhost:8000`
- `kill $PID`
- `node -e "global.window={fetch:async()=>({}),XMLHttpRequest:function(){}}; import('./assets/mockData.js').then(()=>console.log('loaded'));"`


------
https://chatgpt.com/codex/tasks/task_e_68922bf3746c832d9c1c7de9af53d4cc