### PR TITLE
feat: add theme variables and toggle

### DIFF
--- a/assets/index-DjsUcBaW.css
+++ b/assets/index-DjsUcBaW.css
@@ -969,6 +969,16 @@ video {
   --color-light-2: 234 234 234;
   --color-light-3: 240 240 240;
   --color-main-text: 17 17 17;
+  --color-primary: #0d9488;
+  --color-accent: #f59e0b;
+  --color-bg: #ffffff;
+  --color-text: #111111;
+}
+.dark {
+  --color-primary: #34d399;
+  --color-accent: #fcd34d;
+  --color-bg: #111111;
+  --color-text: #f9fafb;
 }
 .container {
   width: 100%;
@@ -1734,8 +1744,8 @@ body {
   position: relative;
   overflow: hidden;
   width: 100%;
-  background: rgb(var(--color-light-1));
-  color: rgb(var(--color-main-text));
+  background: var(--color-bg);
+  color: var(--color-text);
 }
 @keyframes fadeIn {
   0% {

--- a/index.html
+++ b/index.html
@@ -15,8 +15,19 @@
     <title>Emases</title>
     <script type="module" crossorigin src="/assets/index-CytqvZGY.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DjsUcBaW.css" />
+    <style>
+      #theme-toggle:hover {
+        background: var(--color-accent);
+      }
+    </style>
   </head>
   <body>
+    <button id="theme-toggle" style="position: fixed; top: 1rem; right: 1rem; background: var(--color-primary); color: var(--color-text);">Toggle Theme</button>
     <div id="root"></div>
+    <script>
+      document.getElementById('theme-toggle').addEventListener('click', () => {
+        document.documentElement.classList.toggle('dark');
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- introduce CSS variables for primary, accent, background and text
- support light/dark palettes with root `.dark` class
- add toggle button script to switch themes

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68922bfd4a54832da19d0320b053ab83