### PR TITLE
feat: add telemetry patch and inverted theme styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,9 +14,11 @@
     />
     <title>Emases</title>
     <script type="module" src="/assets/mockData.js"></script>
+    <script src="/scripts/patch.js"></script>
     <script type="module" crossorigin src="/assets/index-CytqvZGY.js"></script>
     <script src="/assets/dev-panel.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DjsUcBaW.css" />
+    <link rel="stylesheet" href="/styles/custom.css" />
     <style>
       #theme-toggle:hover {
         background: var(--color-accent);

--- a/scripts/patch.js
+++ b/scripts/patch.js
@@ -1,0 +1,33 @@
+// ==UserScript==
+// @name         Sesame Anti-Telemetry Patch
+// @match        *://app.sesame.com/*
+// @run-at       document-start
+// ==/UserScript==
+
+(() => {
+  const noop = () => {};
+
+  // Proxy-block Sentry
+  window.Sentry = new Proxy({}, {
+    get: () => noop,
+    set: () => true,
+  });
+
+  // Global safety hooks
+  window.onerror = noop;
+  window.onunhandledrejection = noop;
+
+  // Remove debug IDs and breadcrumb tracking
+  window._sentryDebugIds = {};
+  window._sentryDebugIdIdentifier = "";
+
+  // Optional spoofing
+  Object.defineProperty(navigator, 'userAgent', {
+    get: () => "DummyBrowser/7.77"
+  });
+
+  // Optional fingerprinting countermeasure
+  Object.defineProperty(window, 'performance', {
+    get: () => ({ now: () => 0, timing: {} })
+  });
+})();

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -1,0 +1,37 @@
+/* Invert background + text */
+.bg-light1, .bg-white, .bg-blue-100, .bg-gray-200 {
+  background-color: #1a1a1a !important;
+}
+.text-gray-700, .text-main, .text-black {
+  color: #f0f0f0 !important;
+}
+.text-white {
+  color: #111 !important;
+}
+
+/* Invert theme accents */
+.bg-red-400, .bg-red-100 {
+  background-color: #004040 !important;
+}
+.bg-green18, .text-green15 {
+  filter: invert(80%) saturate(60%) !important;
+}
+
+/* Font inversion */
+.font-light { font-weight: 700 !important; }
+.font-bold  { font-weight: 300 !important; }
+
+/* Remove box shadows */
+.shadow-md, .shadow-xl, .shadow-sm, .shadow-subtle {
+  box-shadow: none !important;
+}
+
+/* Square corners */
+.rounded-md, .rounded-l-md, .rounded-r-md {
+  border-radius: 0px !important;
+}
+
+/* Flatten hover contrast */
+:hover {
+  filter: brightness(90%) !important;
+}


### PR DESCRIPTION
## Summary
- inject anti-telemetry script to stub Sentry, neutralize error hooks, and spoof user agent
- apply custom stylesheet that inverts theme colors, fonts, and shadows
- load new script and stylesheet in index.html before the main bundle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689231f01958832da01939ee6e85ab5d