### PR TITLE
fix: defer dev panel script until body loads

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <script type="module" src="/assets/mockData.js"></script>
     <script src="/scripts/patch.js"></script>
     <script type="module" crossorigin src="/assets/index-CytqvZGY.js"></script>
-    <script src="/assets/dev-panel.js"></script>
+    <script src="/assets/dev-panel.js" defer></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DjsUcBaW.css" />
     <link rel="stylesheet" href="/styles/custom.css" />
     <style>


### PR DESCRIPTION
## Summary
- ensure developer panel script runs after DOM is built by deferring execution

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68923a3d2338832d9ef51be5578376d6